### PR TITLE
Setting h5py upper-limit, switching to engine='netcdf4' for HLSPs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=3a67244
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=b26c7fb
+ARG NOTEBOOKS_REF=5c0bd24
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs
@@ -62,7 +62,8 @@ RUN mkdir -p /home/rwddt/.jupyter/lab/workspaces \
 # Install Python and Eureka (no pip cache stored during build)
 RUN mamba install -y -c conda-forge python=3.13 && \
     python -m pip install --no-cache-dir \
-      "eureka-bang[rwddt]@git+https://github.com/kevin218/Eureka.git@${EUREKA_REF}"
+      "eureka-bang[rwddt]@git+https://github.com/kevin218/Eureka.git@${EUREKA_REF}" \
+      "h5py<3.15"
 
 # Optional example notebooks via sparse checkout
 RUN if [ "${INCLUDE_NOTEBOOKS}" = "true" ]; then \

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-b26c7fb}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-5c0bd24}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -22,7 +22,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-b26c7fb}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-5c0bd24}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true


### PR DESCRIPTION
# Summary
Setting h5py upper-limit, switching to engine='netcdf4' for HLSPs

# Motivation
<!-- Why is this change needed? Link to issues/discussions if applicable. -->
Fixes N/A

# Changes
<!-- High-level bullet points of what changed. -->
- h5py upper-limit set to <3.15 (since 3.15 causes `Unspecified error in H5DSis_scale`)
- Changed to engine='netcdf4' for HLSPs for better cross-platform support

# Testing
<!-- How did you verify this works? Commands, datasets, environments, or CI links. -->
- CI testing, manual testing

# Impact
<!-- Note any breaking changes, migrations, or user-visible behavior changes. -->
- Breaking changes: no
- Backwards compatible: yes

# Docs & Release Notes
<!-- List docs updated or to update. If user-facing, add draft release-note text. -->
- Docs updated: no
- Release notes snippet:
  - 

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved