### PR TITLE
Add checkpoint mode and standardize visit naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ docker-compose.yml
 # If you want broader ignore patterns, explicitly keep the template:
 docker-compose.*.yml
 !templates/docker-compose.template.yml
+!templates/docker-compose.checkpoint.template.yml
 !templates/docker-compose.simple.template.yml
+
 
 # Local data and mounted volumes (do not track user-generated results)
 data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=3a67244
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=5c0bd24
+ARG NOTEBOOKS_REF=4f6cde1
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides a containerized **JupyterLab** environment for analyzin
 - You provide local paths at runtime using the configuration script.
 - Generates a `runs/**/docker-compose.yml` file that contains local absolute paths and **must not be committed**.
 
-> **Migration note (breaking change):** If you previously ran `docker compose up` from inside an analyst directory, re-run `./configure_docker_compose.sh` from the repository root. The new workflow generates a per-run directory under `runs/` and you manage the container via `./rwddt-run up/logs/exec/down`.
+> **Migration note (breaking change):** If you previously ran `docker compose up` from inside an analyst directory, re-run `./configure_docker_compose.sh` from the repository root. The workflow generates a per-run directory under `runs/` and you manage the container via `./rwddt-run up/logs/exec/down`.
 
 ---
 
@@ -15,7 +15,7 @@ This repository provides a containerized **JupyterLab** environment for analyzin
 The container provides:
 
 - A fully configured JupyterLab environment with Eureka! preinstalled.
-- Automatic linking of analysis, notebooks, and (optional) input data directories into a stable in-container layout under `/home/rwddt/*`.
+- Stable in-container paths under `/home/rwddt/*` (see “Notes (inside the container)”).
 - Support for both **split-layout** CRDS (common on institutional systems) and **single-layout** CRDS caches (common for community use).
 - Automatic seeding of example notebooks if none exist.
 - A generated Jupyter access URL (with token) printed at startup.
@@ -25,15 +25,14 @@ The container provides:
 ## Prerequisites
 
 - Docker Engine installed and running.
-- Docker Compose v2 available via `docker compose`.
+- Docker Compose v2 available via `docker compose` (Compose plugin).
 - Permission to run Docker (either in the `docker` group or via `sudo`).
 
 ---
 
 ## Files you need
 
-You will need several files from this repo, so you are best-off
-running everything from a local checkout of this repository.
+You will need several files from this repo, so you are best-off running everything from a local checkout of this repository.
 
 ### Option A: Clone with git (recommended)
 
@@ -46,71 +45,25 @@ cd RWDDT_Eureka
 
 Use the GitHub **Code → Download ZIP** button, unzip it, and `cd` into the extracted folder.
 
-### Then configure a run
-
-From the repository root:
-
-```bash
-# Structured mode
-./configure_docker_compose.sh <rootdir> <planet> <visit> <analyst> [<crds_dir>] [split|single]
-
-# Simple mode
-./configure_docker_compose.sh --simple [<crds_dir>] [split|single]
-```
-
-This will generate a run directory under `runs/` containing a generated `docker-compose.yml`, a `.rwddt_state` metadata file, and a `rwddt-run` wrapper script.
-
 ---
 
-## Folder structure (Structured Mode)
+## Configure a run (from repository root)
 
-Structured mode expects your host filesystem to look like:
-
-```text
-<rootdir>/JWST/<planet>/<visit>/
-├── <analyst>/
-│   └── notebooks/
-├── MAST_Stage1/        (optional)
-└── Uncalibrated/       (optional)
-```
-
-Notes:
-
-- The script will create `<rootdir>/JWST/<planet>/<visit>/<analyst>/notebooks/` if needed.
-- `MAST_Stage1` and `Uncalibrated` are **optional** for community users.
-- `MAST_Stage1` and `Uncalibrated` are mounted automatically **only if those directories exist** on the host at configure time.
-
----
-
-## Mount & isolation model (Structured Mode)
-
-To keep notebooks simple **and** prevent analysts from seeing each other’s work:
-
-- The container bind-mounts **only what is needed**:
-  - the analyst folder (read/write)
-  - `MAST_Stage1` (read-only, **only if it exists on the host**)
-  - `Uncalibrated` (read-only, **only if it exists on the host**)
-- Inside the container, stable paths are provided via symlinks:
-  - `/home/rwddt/analysis` → your analyst folder
-  - `/home/rwddt/notebooks` → your notebooks
-  - `/home/rwddt/MAST_Stage1` and `/home/rwddt/Uncalibrated` → input folders (or empty dirs if not present)
-
----
-
-## 1) Configure the container
-
-### Structured mode (recommended)
-
-From the repository root:
+### Structured mode (recommended; single visit)
 
 ```bash
-./configure_docker_compose.sh <rootdir> <planet> <visit> <analyst> [<crds_dir>] [split|single]
+./configure_docker_compose.sh <rootdir> <planet> <visit_num> <analyst> [<crds_dir>] [split|single]
 ```
 
-Example (community single-layout CRDS):
+**Visit argument rule (important):**
+
+- `<visit_num>` should be an **integer**, e.g. `12`.
+- For backward compatibility, `visit12` and `visit012` are accepted, but are normalized to the directory name `visit12` (no zero padding).
+
+**Example (community single-layout CRDS):**
 
 ```bash
-./configure_docker_compose.sh $HOME/data TOI-1234b visit1 Analyst_A $HOME/crds_cache single
+./configure_docker_compose.sh $HOME/data TOI-1234b 1 Analyst_A $HOME/crds_cache single
 ```
 
 This creates:
@@ -122,12 +75,46 @@ runs/<planet>_<visit>/
 └── rwddt-run
 ```
 
+> Note: `<visit>` will be the normalized visit directory name, e.g. `visit1`, `visit12`.
+
+---
+
+### Checkpoint mode (joint fit across multiple visits)
+
+Checkpoint mode is intended for combining outputs from multiple prior visits (mounted **read-only**) and writing new joint-fit outputs into a checkpoint workspace (mounted **read-write**).
+
+```bash
+./configure_docker_compose.sh --checkpoint <rootdir> <planet> <checkpoint> <analyst> <max_visit_num> \
+    [<crds_dir>] [split|single]
+```
+
+**Semantics:**
+
+- Visit roots `visit1 ... visit<max_visit_num>` are mounted **read-only** (missing visits are skipped with a warning).
+- The checkpoint analyst folder is created/mounted **read-write** at:
+  - Host: `<rootdir>/JWST/<planet>/<checkpoint>/<analyst>/`
+  - Container: `/mnt/rwddt/JWST/<planet>/<checkpoint>/<analyst>/`
+
+**Example:**
+
+```bash
+./configure_docker_compose.sh --checkpoint $HOME/data TOI-1234b checkpoint1 Analyst_A 12 $HOME/crds_cache single
+```
+
+This creates:
+
+```text
+runs/<planet>_<checkpoint>_maxvisit<max_visit_num>/
+├── docker-compose.yml
+├── .rwddt_state
+└── rwddt-run
+```
+
+---
+
 ### Simple mode (quick tests)
 
-Simple mode is for quick tests when you **don’t** want to create a host directory tree.
-By default, work lives inside the container and is **not persisted** if the container is removed.
-
-From the repository root:
+Simple mode is for quick tests when you **don’t** want to create a host directory tree. By default, work lives inside the container and is **not persisted** if the container is removed.
 
 ```bash
 ./configure_docker_compose.sh --simple [<crds_dir>] [split|single]
@@ -150,6 +137,146 @@ runs/simple_YYYYmmdd_HHMMSS/
 ├── docker-compose.yml
 ├── .rwddt_state
 └── rwddt-run
+```
+
+---
+
+## Folder structure on host
+
+### Structured Mode (single visit)
+
+Structured mode expects your host filesystem to look like:
+
+```text
+<rootdir>/JWST/<planet>/visit<visit_num>/
+├── <analyst>/
+│   └── notebooks/
+├── MAST_Stage1/        (optional)
+└── Uncalibrated/       (optional)
+```
+
+Notes:
+
+- The script will create `<rootdir>/JWST/<planet>/visit<visit_num>/<analyst>/notebooks/` if needed.
+- `MAST_Stage1` and `Uncalibrated` are optional.
+- They are mounted automatically **only if those directories exist** on the host at configure time.
+
+---
+
+### Checkpoint Mode
+
+Checkpoint mode assumes you already have visits laid out as:
+
+```text
+<rootdir>/JWST/<planet>/
+├── visit1/
+├── visit2/
+├── ...
+└── visitN/
+```
+
+and creates a new checkpoint workspace:
+
+```text
+<rootdir>/JWST/<planet>/<checkpoint>/
+└── <analyst>/
+    └── notebooks/
+```
+
+Notes:
+
+- Visit roots are mounted **read-only**.
+- The checkpoint analyst folder is mounted **read-write**.
+
+---
+
+## Mount & isolation model
+
+### Structured Mode
+
+To keep notebooks simple **and** prevent analysts from seeing each other’s work:
+
+- The container bind-mounts **only what is needed**:
+  - the analyst folder (read/write)
+  - `MAST_Stage1` (read-only, only if it exists on the host)
+  - `Uncalibrated` (read-only, only if it exists on the host)
+- Inside the container, stable paths are provided via symlinks:
+  - `/home/rwddt/analysis` → your analyst folder
+  - `/home/rwddt/notebooks` → your notebooks
+  - `/home/rwddt/MAST_Stage1` and `/home/rwddt/Uncalibrated` → input folders (or empty dirs if not present)
+
+### Checkpoint Mode
+
+- The container bind-mounts:
+  - the checkpoint analyst folder (read/write)
+  - visit roots `visit1..visitN` (read-only)
+- Inside the container:
+  - `/home/rwddt/analysis` → checkpoint analyst folder (RW)
+  - `/home/rwddt/notebooks` → checkpoint notebooks (RW)
+  - `/home/rwddt/visits` → `/mnt/rwddt/JWST/<planet>` (RO visit roots + checkpoint folder)
+- **In checkpoint mode, `/home/rwddt/MAST_Stage1` and `/home/rwddt/Uncalibrated` are not created.**
+
+---
+
+## Start the container
+
+Change into the run directory and start:
+
+```bash
+cd runs/<run_name>
+./rwddt-run up
+```
+
+Examples:
+
+```bash
+# structured
+cd runs/<planet>_visit12
+./rwddt-run up
+
+# checkpoint
+cd runs/<planet>_checkpoint1_maxvisit12
+./rwddt-run up
+```
+
+---
+
+## Access JupyterLab
+
+### View the access URL
+
+```bash
+./rwddt-run logs
+```
+
+If the URL/token doesn’t appear immediately, wait ~5–15 seconds and run `./rwddt-run logs` again.
+
+### Remote host port-forwarding
+
+If Docker is running on a remote host, you’ll need SSH port forwarding:
+
+```bash
+ssh -L <hostport>:localhost:<hostport> <user>@<remote-host>
+```
+
+Keep that terminal open while you use JupyterLab; type `exit` to close the tunnel when finished.
+
+You can also print a helper snippet with:
+
+```bash
+./rwddt-run url
+```
+
+---
+
+## Useful wrapper commands
+
+```bash
+./rwddt-run info     # show what this run directory is configured for
+./rwddt-run exec bash
+./rwddt-run ps
+./rwddt-run down
+./rwddt-run update   # pull newest image + recreate
 ```
 
 ---
@@ -178,70 +305,13 @@ cd runs/simple_YYYYmmdd_HHMMSS
 ./rwddt-run up
 ```
 
-> Tip: Structured Mode is still the best choice for collaboration and consistent shared host layout; Simple Mode persistence is intended for quick, self-contained experiments.
-
----
-
-## 2) Start the container
-
-Change into the run directory and start:
-
-```bash
-cd runs/<planet>_<visit>
-./rwddt-run up
-```
-
-For simple mode:
-
-```bash
-cd runs/simple_YYYYmmdd_HHMMSS
-./rwddt-run up
-```
-
----
-
-## 3) Access JupyterLab
-
-### View the access URL
-
-```bash
-./rwddt-run logs
-```
-
-If the URL/token doesn’t appear immediately, wait ~5–15 seconds and run `./rwddt-run logs` again.
-
-### Remote host port-forwarding
-
-If Docker is running on a remote host, you'll need to set up SSH-based port forwarding using the
-command provided in the Docker logs that will look something like:
-
-```bash
-ssh -L <hostport>:localhost:<hostport> <user>@<remote-host>
-```
-
-Keep that terminal open while you use JupyterLab; type `exit` to close the tunnel when finished.
-
----
-
-## Updating to the newest DockerHub image version
-
-```bash
-./rwddt-run update
-```
-
----
-
-## Stopping the container
-
-```bash
-./rwddt-run down
-```
+> Tip: Structured Mode is best for collaboration and consistent shared host layout; Simple Mode persistence is intended for quick, self-contained experiments.
 
 ---
 
 ## Optional environment overrides
 
-These can be set in your shell before running `./rwddt-run up`:
+Set these in your shell before running `./rwddt-run up`:
 
 - `IMAGE` — override which container image to run (useful for local builds).
 - `CRDS_MODE=remote` — run without requiring a local CRDS cache directory on the host (uses the CRDS server).
@@ -258,12 +328,18 @@ These can be set in your shell before running `./rwddt-run up`:
 
 ## Notes (inside the container)
 
-| Container Path              | Purpose                                           |
-|----------------------------|---------------------------------------------------|
-| `/home/rwddt/notebooks/`   | Editable notebooks                                |
-| `/home/rwddt/analysis/`    | Analyst writable area                             |
-| `/home/rwddt/MAST_Stage1/` | Shared Stage 1 inputs (RO if present; else empty) |
-| `/home/rwddt/Uncalibrated/`| Shared Stage 0 inputs (RO if present; else empty) |
+### Structured mode paths
+
+- `/home/rwddt/notebooks/` — editable notebooks
+- `/home/rwddt/analysis/` — analyst writable area
+- `/home/rwddt/MAST_Stage1/` — shared Stage 1 inputs (RO if present; else empty)
+- `/home/rwddt/Uncalibrated/` — shared Stage 0 inputs (RO if present; else empty)
+
+### Checkpoint mode paths
+
+- `/home/rwddt/notebooks/` — checkpoint notebooks (RW)
+- `/home/rwddt/analysis/` — checkpoint workspace (RW)
+- `/home/rwddt/visits/` — browse visit roots under this planet (primarily RO)
 
 ---
 

--- a/configure_docker_compose.sh
+++ b/configure_docker_compose.sh
@@ -548,4 +548,27 @@ if [[ "$MODE" == "structured" ]]; then
   echo
   echo "Structured dataset:"
   echo "  planet  = \"$PLANET\""
+  echo "  visit   = \"$VISIT\""
+  echo "  analyst = \"$ANALYST\""
+elif [[ "$MODE" == "checkpoint" ]]; then
+  echo
+  echo "Checkpoint dataset:"
+  echo "  planet     = \"$PLANET\""
+  echo "  checkpoint = \"$CHECKPOINT\""
+  echo "  analyst    = \"$ANALYST\""
+  echo "  max_visit  = \"$MAX_VISIT_NUM\""
+  echo "  mounted    = \"$MOUNTED_VISITS_CSV\""
+  echo "  checkpointRW = \"$CHECKPOINT_ANALYSIS_DIR\""
+fi
+
+echo
+echo -e "${GREEN}Next steps:${NC}"
+echo "  cd \"$RUN_DIR\""
+echo "  ./$WRAPPER up"
+echo "  ./$WRAPPER logs   # shows Jupyter URL + token"
+echo "                     # (If it looks empty at first, wait ~5–15 seconds and run it again.)"
+echo "  ./$WRAPPER url    # prints ssh port-forward helper"
+echo
+echo "If you need to update the Docker image to a new version:"
+echo "  ./$WRAPPER update # pull latest image + recreate"
 

--- a/configure_docker_compose.sh
+++ b/configure_docker_compose.sh
@@ -5,14 +5,28 @@ set -euo pipefail
 # configure_docker_compose.sh
 #
 # Structured mode (recommended):
-#   ./configure_docker_compose.sh <rootdir> <planet> <visit> <analyst> [<crds_dir>] [split|single]
+#   ./configure_docker_compose.sh <rootdir> <planet> <visit_num> <analyst> [<crds_dir>] [split|single]
+#
+#   - <visit_num> is an integer (e.g. 12). For backward compatibility we also accept:
+#       visit12, visit012
+#     and normalize to: visit12 (no zero padding).
 #
 # Simple mode (quick tests; no required host structure; no persistence by default):
 #   ./configure_docker_compose.sh --simple [<crds_dir>] [split|single]
 #
+# Checkpoint mode (joint Stage 5 using multiple visits' outputs):
+#   ./configure_docker_compose.sh --checkpoint <rootdir> <planet> <checkpoint> <analyst> <max_visit_num> \
+#       [<crds_dir>] [split|single]
+#
+#   - Mounts visit roots read-only for visit1..visit<max_visit_num> (skips missing with warning)
+#   - Creates a new checkpoint folder (RW) at:
+#       <rootdir>/JWST/<planet>/<checkpoint>/<analyst>
+#
 # Outputs a run directory under:
-#   runs/<planet>_<visit>/           (structured)
-#   runs/simple_<timestamp>/         (simple)
+#   runs/<planet>_<visit>/                     (structured)
+#   runs/simple_<timestamp>/                   (simple)
+#   runs/<planet>_<checkpoint>_maxvisit<N>/    (checkpoint)
+#
 # containing:
 #   - docker-compose.yml
 #   - .rwddt_state
@@ -23,16 +37,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNS_ROOT="${SCRIPT_DIR}/runs"
 
-# Templates now live under templates/
+# Templates live under templates/
 TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 
 STRUCT_TEMPLATE_FILE="docker-compose.template.yml"
 SIMPLE_TEMPLATE_FILE="docker-compose.simple.template.yml"
+CHECKPOINT_TEMPLATE_FILE="docker-compose.checkpoint.template.yml"
 BANNER_TEMPLATE_FILE="generated-compose-banner.txt"
 WRAPPER_TEMPLATE_FILE="rwddt-run.template.sh"
 
 STRUCT_TEMPLATE_PATH="${TEMPLATES_DIR}/${STRUCT_TEMPLATE_FILE}"
 SIMPLE_TEMPLATE_PATH="${TEMPLATES_DIR}/${SIMPLE_TEMPLATE_FILE}"
+CHECKPOINT_TEMPLATE_PATH="${TEMPLATES_DIR}/${CHECKPOINT_TEMPLATE_FILE}"
 BANNER_TEMPLATE_PATH="${TEMPLATES_DIR}/${BANNER_TEMPLATE_FILE}"
 WRAPPER_TEMPLATE_PATH="${TEMPLATES_DIR}/${WRAPPER_TEMPLATE_FILE}"
 
@@ -51,16 +67,59 @@ usage() {
   cat <<'USAGE'
 Usage:
   Structured mode (recommended):
-    ./configure_docker_compose.sh <rootdir> <planet> <visit> <analyst> [<crds_dir>] [split|single]
+    ./configure_docker_compose.sh <rootdir> <planet> <visit_num> <analyst> [<crds_dir>] [split|single]
+
+    Notes:
+      - <visit_num> must be an integer (e.g. 12). For backward compatibility also accepts:
+          visit12, visit012
+        and will normalize to: visit12 (no zero padding).
 
   Simple mode (quick tests; no required host structure; no persistence by default):
     ./configure_docker_compose.sh --simple [<crds_dir>] [split|single]
 
-Notes:
+  Checkpoint mode (joint Stage 5 using multiple visits' outputs):
+    ./configure_docker_compose.sh --checkpoint <rootdir> <planet> <checkpoint> <analyst> <max_visit_num> \
+        [<crds_dir>] [split|single]
+
+    Notes:
+      - Checkpoint mode mounts visit roots read-only for visit1..visit<max_visit_num>.
+      - Visit directories are expected to be named: visit1, visit2, ... (no zero padding).
+      - Checkpoint work area is created read-write at:
+          <rootdir>/JWST/<planet>/<checkpoint>/<analyst>
+
+CRDS layout:
+  - split  mounts CRDS read-only at /grp/crds and sets CRDS_PATH=/grp/crds/cache
+  - single mounts CRDS read-write at /crds     and sets CRDS_PATH=/crds
+
+General:
   - <rootdir> must be an absolute path.
-  - split layout mounts CRDS read-only at /grp/crds and sets CRDS_PATH=/grp/crds/cache
-  - single layout mounts CRDS read-write at /crds and sets CRDS_PATH=/crds
 USAGE
+}
+
+normalize_visit() {
+  # Accept: "12", "visit12", "visit012" -> normalize to VISIT_NUM=12, VISIT_DIR="visit12"
+  local raw="$1"
+  local num=""
+
+  if [[ "$raw" =~ ^[0-9]+$ ]]; then
+    num="$raw"
+  elif [[ "$raw" =~ ^visit([0-9]+)$ ]]; then
+    num="${BASH_REMATCH[1]}"
+  else
+    echo "Error: visit must be an integer (e.g. 12) or 'visit#' (e.g. visit12). Got '$raw'." >&2
+    exit 1
+  fi
+
+  # Force base-10 parse to drop leading zeros safely
+  num=$((10#$num))
+
+  if (( num < 1 )); then
+    echo "Error: visit number must be >= 1 (got '$num')." >&2
+    exit 1
+  fi
+
+  VISIT_NUM="$num"
+  VISIT_DIR="visit${VISIT_NUM}"
 }
 
 escape_sed_repl() {
@@ -90,15 +149,37 @@ uncomment_volume_line_for_placeholder() {
     "$file"
 }
 
+ensure_templates_exist() {
+  local mode="$1"
+  shift || true
+  local files=("$@")
+  local f
+  for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+      echo "Error: required template not found for mode '${mode}': $f" >&2
+      exit 1
+    fi
+  done
+}
+
 # -------- argument parsing --------
 MODE="structured"
 if [[ "${1:-}" == "--simple" ]]; then
   MODE="simple"
   shift || true
+elif [[ "${1:-}" == "--checkpoint" ]]; then
+  MODE="checkpoint"
+  shift || true
 fi
 
 CRDS_DIR_DEFAULT="${HOME}/crds_cache"
 LAYOUT_DEFAULT="single"
+
+# Initialize vars (avoid unbound errors under set -u)
+ROOTDIR=""; PLANET=""; VISIT=""; ANALYST=""; CHECKPOINT=""
+MAX_VISIT_NUM=""
+CRDS_DIR="$CRDS_DIR_DEFAULT"
+CRDS_LAYOUT="$LAYOUT_DEFAULT"
 
 if [[ "$MODE" == "structured" ]]; then
   if [ "$#" -lt 4 ] || [ "$#" -gt 6 ]; then
@@ -108,10 +189,13 @@ if [[ "$MODE" == "structured" ]]; then
 
   ROOTDIR=$1
   PLANET=$2
-  VISIT=$3
+  RAW_VISIT=$3
   ANALYST=$4
   CRDS_DIR="${5:-$CRDS_DIR_DEFAULT}"
   CRDS_LAYOUT="${6:-$LAYOUT_DEFAULT}"
+
+  normalize_visit "$RAW_VISIT"
+  VISIT="$VISIT_DIR"  # always "visit#"
 
   case "$ROOTDIR" in
     /*) : ;;
@@ -129,14 +213,10 @@ if [[ "$MODE" == "structured" ]]; then
     exit 1
   fi
 
-  # Ensure required templates exist
-  for f in "$STRUCT_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"; do
-    if [ ! -f "$f" ]; then
-      echo "Error: required template not found: $f" >&2
-      exit 1
-    fi
-  done
-else
+  ensure_templates_exist "structured" \
+    "$STRUCT_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"
+
+elif [[ "$MODE" == "simple" ]]; then
   if [ "$#" -gt 2 ]; then
     usage
     exit 1
@@ -145,18 +225,59 @@ else
   CRDS_DIR="${1:-$CRDS_DIR_DEFAULT}"
   CRDS_LAYOUT="${2:-$LAYOUT_DEFAULT}"
 
-  # Ensure required templates exist
-  for f in "$SIMPLE_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"; do
-    if [ ! -f "$f" ]; then
-      echo "Error: required template not found: $f" >&2
-      exit 1
-    fi
-  done
+  ensure_templates_exist "simple" \
+    "$SIMPLE_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"
 
-  ROOTDIR=""
-  PLANET=""
-  VISIT=""
-  ANALYST=""
+elif [[ "$MODE" == "checkpoint" ]]; then
+  # Mandatory positional args:
+  #   <rootdir> <planet> <checkpoint> <analyst> <max_visit_num>
+  # Optional:
+  #   [<crds_dir>] [split|single]
+  if [ "$#" -lt 5 ] || [ "$#" -gt 7 ]; then
+    usage
+    exit 1
+  fi
+
+  ROOTDIR=$1
+  PLANET=$2
+  CHECKPOINT=$3
+  ANALYST=$4
+  MAX_VISIT_RAW=$5
+  CRDS_DIR="${6:-$CRDS_DIR_DEFAULT}"
+  CRDS_LAYOUT="${7:-$LAYOUT_DEFAULT}"
+
+  case "$ROOTDIR" in
+    /*) : ;;
+    *) echo "Error: <rootdir> must be an absolute path (got '$ROOTDIR')." >&2; exit 1 ;;
+  esac
+  if [ ! -d "$ROOTDIR" ]; then
+    echo "Error: <rootdir> '$ROOTDIR' does not exist or is not a directory." >&2
+    exit 1
+  fi
+
+  if ! [[ "$MAX_VISIT_RAW" =~ ^[0-9]+$ ]]; then
+    echo "Error: <max_visit_num> must be an integer (got '$MAX_VISIT_RAW')." >&2
+    exit 1
+  fi
+  MAX_VISIT_NUM=$((10#$MAX_VISIT_RAW))
+  if (( MAX_VISIT_NUM < 1 )); then
+    echo "Error: <max_visit_num> must be >= 1 (got '$MAX_VISIT_NUM')." >&2
+    exit 1
+  fi
+
+  PLANET_DIR="${ROOTDIR%/}/JWST/${PLANET}"
+  if [ ! -d "$PLANET_DIR" ]; then
+    echo "Error: planet directory does not exist: $PLANET_DIR" >&2
+    echo "Create $ROOTDIR/JWST/$PLANET first, or fix your arguments." >&2
+    exit 1
+  fi
+
+  ensure_templates_exist "checkpoint" \
+    "$CHECKPOINT_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"
+else
+  echo "Error: unknown MODE '$MODE'." >&2
+  usage
+  exit 1
 fi
 
 # -------- resolve IDs for correct file ownership on host --------
@@ -214,28 +335,29 @@ HOST_PORT="$(find_free_port)" || { echo "could not find a free port" >&2; exit 1
 # -------- naming + run directory --------
 USER_SAFE="$(sanitize "${USER:-unknown}")"
 
+PLANET_SAFE="$(sanitize "${PLANET:-unknown}")"
+
 if [[ "$MODE" == "structured" ]]; then
-  PLANET_SAFE="$(sanitize "$PLANET")"
   VISIT_SAFE="$(sanitize "$VISIT")"
   DATASET_SAFE="${PLANET_SAFE}_${VISIT_SAFE}"
   RUN_DIR="${RUNS_ROOT}/${DATASET_SAFE}"
   PROJECT_NAME="rwddt_${USER_SAFE}_${DATASET_SAFE}"
 
-  BASE_VISIT_DIR="$ROOTDIR/JWST/$PLANET/$VISIT"
+  BASE_VISIT_DIR="${ROOTDIR%/}/JWST/${PLANET}/${VISIT}"
   ANALYSIS_DIR="$BASE_VISIT_DIR/$ANALYST"
   NOTEBOOKS_DIR="$ANALYSIS_DIR/notebooks"
 
   MAST_STAGE1_DIR="$BASE_VISIT_DIR/MAST_Stage1"
   UNCAL_DIR="$BASE_VISIT_DIR/Uncalibrated"
 
-  # Create analyst notebooks directory (creates ANALYSIS_DIR as needed)
   mkdir -p "$NOTEBOOKS_DIR"
 
   # Ensure minimum perms (add-only; never reduces existing perms)
   chmod u+rwx "$ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
   chmod g+s "$ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
   chmod o+x  "$ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
-else
+
+elif [[ "$MODE" == "simple" ]]; then
   TS="$(date +%Y%m%d_%H%M%S)"
   DATASET_SAFE="simple_${TS}"
   RUN_DIR="${RUNS_ROOT}/${DATASET_SAFE}"
@@ -245,6 +367,25 @@ else
   NOTEBOOKS_DIR=""
   MAST_STAGE1_DIR=""
   UNCAL_DIR=""
+
+elif [[ "$MODE" == "checkpoint" ]]; then
+  CHECKPOINT_SAFE="$(sanitize "$CHECKPOINT")"
+  # Include planet + checkpoint + maxvisit so multiple checkpoints don't collide
+  DATASET_SAFE="${PLANET_SAFE}_${CHECKPOINT_SAFE}_maxvisit${MAX_VISIT_NUM}"
+  RUN_DIR="${RUNS_ROOT}/${DATASET_SAFE}"
+  PROJECT_NAME="rwddt_${USER_SAFE}_${DATASET_SAFE}"
+
+  CHECKPOINT_ANALYSIS_DIR="${ROOTDIR%/}/JWST/${PLANET}/${CHECKPOINT}/${ANALYST}"
+  NOTEBOOKS_DIR="${CHECKPOINT_ANALYSIS_DIR}/notebooks"
+  mkdir -p "$NOTEBOOKS_DIR"
+
+  chmod u+rwx "$CHECKPOINT_ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
+  chmod g+s "$CHECKPOINT_ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
+  chmod o+x  "$CHECKPOINT_ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
+
+  ANALYSIS_DIR=""       # not used
+  MAST_STAGE1_DIR=""    # not used
+  UNCAL_DIR=""          # not used
 fi
 
 mkdir -p "$RUN_DIR"
@@ -254,17 +395,70 @@ STATE_PATH="${RUN_DIR}/${STATE_FILE}"
 WRAPPER_PATH="${RUN_DIR}/${WRAPPER}"
 
 # -----------------------------------------------------------------------------
-# Generate docker-compose.yml from template (both modes)
+# Generate docker-compose.yml from template (all modes)
 #   - Prepend banner from templates/generated-compose-banner.txt
 # -----------------------------------------------------------------------------
 TEMPLATE_TO_USE="$STRUCT_TEMPLATE_PATH"
 if [[ "$MODE" == "simple" ]]; then
   TEMPLATE_TO_USE="$SIMPLE_TEMPLATE_PATH"
+elif [[ "$MODE" == "checkpoint" ]]; then
+  TEMPLATE_TO_USE="$CHECKPOINT_TEMPLATE_PATH"
 fi
 
 # banner + template -> output
 cat "$BANNER_TEMPLATE_PATH" "$TEMPLATE_TO_USE" > "$OUTPUT_PATH"
 
+# -----------------------------------------------------------------------------
+# Checkpoint mode: inject RO mounts for visit roots visit1..visitN
+#   The checkpoint template must include a line:
+#     # __VISIT_ROOT_MOUNTS__
+# -----------------------------------------------------------------------------
+MOUNTED_VISITS_CSV=""
+if [[ "$MODE" == "checkpoint" ]]; then
+  PLANET_DIR="${ROOTDIR%/}/JWST/${PLANET}"
+
+  VIS_TMP="$(mktemp)"
+  : > "$VIS_TMP"
+
+  declare -a MOUNTED_VISITS=()
+
+  for ((i=1; i<=MAX_VISIT_NUM; i++)); do
+    vdir="visit${i}"
+    host="${PLANET_DIR}/${vdir}"
+    if [[ -d "$host" ]]; then
+      # Mount visit root read-only at the same relative path inside container
+      printf '      - %s:/mnt/rwddt/JWST/%s/%s:ro\n' "$host" "$PLANET" "$vdir" >> "$VIS_TMP"
+      MOUNTED_VISITS+=("$vdir")
+    else
+      echo "Warning: missing visit directory (skipping): $host" >&2
+    fi
+  done
+
+  if (( ${#MOUNTED_VISITS[@]} == 0 )); then
+    echo "Error: no visit directories found from visit1..visit${MAX_VISIT_NUM} under $PLANET_DIR" >&2
+    rm -f "$VIS_TMP" 2>/dev/null || true
+    exit 1
+  fi
+
+  MOUNTED_VISITS_CSV="$(IFS=,; echo "${MOUNTED_VISITS[*]}")"
+
+  # Robust insertion via awk (avoids sed newline escaping headaches)
+  OUT_TMP="$(mktemp)"
+  awk -v mounts_file="$VIS_TMP" '
+    { print }
+    /# __VISIT_ROOT_MOUNTS__/ {
+      while ((getline line < mounts_file) > 0) print line
+      close(mounts_file)
+    }
+  ' "$OUTPUT_PATH" > "$OUT_TMP"
+  mv "$OUT_TMP" "$OUTPUT_PATH"
+
+  rm -f "$VIS_TMP" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
+# Fill placeholders
+# -----------------------------------------------------------------------------
 if [[ "$MODE" == "structured" ]]; then
   # Uncomment optional mounts only if host dirs exist
   if [[ -d "$MAST_STAGE1_DIR" ]]; then
@@ -279,11 +473,18 @@ if [[ "$MODE" == "structured" ]]; then
   replace_placeholder "$OUTPUT_PATH" "uncalibrated_host" "$UNCAL_DIR"
 
   replace_placeholder "$OUTPUT_PATH" "planet" "$PLANET"
-  replace_placeholder "$OUTPUT_PATH" "visit" "$VISIT"
+  replace_placeholder "$OUTPUT_PATH" "visit" "$VISIT"     # "visit#"
   replace_placeholder "$OUTPUT_PATH" "analyst" "$ANALYST"
 fi
 
-# Common placeholders for both modes
+if [[ "$MODE" == "checkpoint" ]]; then
+  replace_placeholder "$OUTPUT_PATH" "planet" "$PLANET"
+  replace_placeholder "$OUTPUT_PATH" "checkpoint" "$CHECKPOINT"
+  replace_placeholder "$OUTPUT_PATH" "analyst" "$ANALYST"
+  replace_placeholder "$OUTPUT_PATH" "checkpoint_dir_host" "$CHECKPOINT_ANALYSIS_DIR"
+fi
+
+# Common placeholders for all modes
 replace_placeholder "$OUTPUT_PATH" "project_name" "$PROJECT_NAME"
 replace_placeholder "$OUTPUT_PATH" "hostport" "$HOST_PORT"
 replace_placeholder "$OUTPUT_PATH" "uid" "$ANALYST_UID"
@@ -315,6 +516,12 @@ write_kv() {
   write_kv ANALYST "$ANALYST"
   write_kv HOST_PORT "$HOST_PORT"
   write_kv COMPOSE_FILE "$OUTPUT_FILE"
+
+  if [[ "$MODE" == "checkpoint" ]]; then
+    write_kv CHECKPOINT "$CHECKPOINT"
+    write_kv MAX_VISIT_NUM "$MAX_VISIT_NUM"
+    write_kv VISITS_CSV "$MOUNTED_VISITS_CSV"
+  fi
 } > "$STATE_PATH"
 
 # -----------------------------------------------------------------------------
@@ -336,14 +543,9 @@ echo "  CRDS dir    = \"$CRDS_DIR\""
 echo "  CRDS layout = \"$CRDS_LAYOUT\""
 echo "  CRDS target = \"$CRDS_TARGET\" (container)"
 echo "  CRDS mode   = \"$CRDS_BIND_MODE\""
-echo
-echo -e "${GREEN}Next steps:${NC}"
-echo "  cd \"$RUN_DIR\""
-echo "  ./$WRAPPER up"
-echo "  ./$WRAPPER logs   # shows Jupyter URL + token"
-echo "                     # (If it looks empty at first, wait ~5–15 seconds and run it again.)"
-echo "  ./$WRAPPER url    # prints ssh port-forward helper"
-echo
-echo "If you need to update the Docker image to a new version:"
-echo "  ./$WRAPPER update # pull latest image + recreate"
+
+if [[ "$MODE" == "structured" ]]; then
+  echo
+  echo "Structured dataset:"
+  echo "  planet  = \"$PLANET\""
 

--- a/configure_docker_compose.sh
+++ b/configure_docker_compose.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+umask 002
 
 # -----------------------------------------------------------------------------
 # configure_docker_compose.sh
@@ -21,6 +22,9 @@ set -euo pipefail
 #   - Mounts visit roots read-only for visit1..visit<max_visit_num> (skips missing with warning)
 #   - Creates a new checkpoint folder (RW) at:
 #       <rootdir>/JWST/<planet>/<checkpoint>/<analyst>
+#
+# Optional:
+#   --force  Overwrite generated files inside the run directory if they already exist.
 #
 # Outputs a run directory under:
 #   runs/<planet>_<visit>/                     (structured)
@@ -67,7 +71,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   Structured mode (recommended):
-    ./configure_docker_compose.sh <rootdir> <planet> <visit_num> <analyst> [<crds_dir>] [split|single]
+    ./configure_docker_compose.sh [--force] <rootdir> <planet> <visit_num> <analyst> [<crds_dir>] [split|single]
 
     Notes:
       - <visit_num> must be an integer (e.g. 12). For backward compatibility also accepts:
@@ -75,10 +79,10 @@ Usage:
         and will normalize to: visit12 (no zero padding).
 
   Simple mode (quick tests; no required host structure; no persistence by default):
-    ./configure_docker_compose.sh --simple [<crds_dir>] [split|single]
+    ./configure_docker_compose.sh --simple [--force] [<crds_dir>] [split|single]
 
   Checkpoint mode (joint Stage 5 using multiple visits' outputs):
-    ./configure_docker_compose.sh --checkpoint <rootdir> <planet> <checkpoint> <analyst> <max_visit_num> \
+    ./configure_docker_compose.sh --checkpoint [--force] <rootdir> <planet> <checkpoint> <analyst> <max_visit_num> \
         [<crds_dir>] [split|single]
 
     Notes:
@@ -93,6 +97,7 @@ CRDS layout:
 
 General:
   - <rootdir> must be an absolute path.
+  - --force overwrites generated files in the run directory (docker-compose.yml/.rwddt_state/rwddt-run).
 USAGE
 }
 
@@ -112,7 +117,6 @@ normalize_visit() {
 
   # Force base-10 parse to drop leading zeros safely
   num=$((10#$num))
-
   if (( num < 1 )); then
     echo "Error: visit number must be >= 1 (got '$num')." >&2
     exit 1
@@ -123,7 +127,7 @@ normalize_visit() {
 }
 
 escape_sed_repl() {
-  # Escape characters that are special in sed replacement:
+  # Escape special characters in sed replacement:
   # - '&' expands to the match
   # - '\' starts escape sequences
   # - '|' is our chosen delimiter
@@ -155,11 +159,51 @@ ensure_templates_exist() {
   local files=("$@")
   local f
   for f in "${files[@]}"; do
-    if [ ! -f "$f" ]; then
+    if [[ ! -f "$f" ]]; then
       echo "Error: required template not found for mode '${mode}': $f" >&2
       exit 1
     fi
   done
+}
+
+# Derive a shared group name from ROOTDIR (without hard-coding any group name).
+# We use ROOTDIR's group owner as the "shared" group.
+get_rootdir_group_name() {
+  local rootdir="$1"
+  local g=""
+  g="$(stat -c '%G' "$rootdir" 2>/dev/null || true)"
+  [[ -n "$g" && "$g" != "UNKNOWN" ]] && printf '%s' "$g" || return 1
+}
+
+# Resolve a group name to GID (portable-ish)
+gid_of_group() {
+  local gname="$1"
+  getent group "$gname" 2>/dev/null | awk -F: '{print $3}' | head -n1
+}
+
+# Make generated files safe for shared hosts where docker is run via sudo/root-squash:
+# - ensure readable compose/state
+# - ensure group matches the run directory group (best-effort)
+fix_run_permissions() {
+  local run_dir="$1"
+  local compose_path="$2"
+  local state_path="$3"
+  local wrapper_path="$4"
+
+  # Ensure directory traversal works for sudo/root-squash contexts
+  chmod o+rx "$run_dir" 2>/dev/null || true
+  chmod o+rx "$(dirname "$run_dir")" 2>/dev/null || true
+
+  # Best-effort: set group to match run directory group
+  local run_group=""
+  run_group="$(stat -c '%G' "$run_dir" 2>/dev/null || true)"
+  if [[ -n "$run_group" && "$run_group" != "UNKNOWN" ]]; then
+    chgrp "$run_group" "$compose_path" "$state_path" "$wrapper_path" 2>/dev/null || true
+  fi
+
+  # Critical: ensure compose/state are readable by sudo/root-squash; keep group writable for team usage
+  chmod 664 "$compose_path" "$state_path" 2>/dev/null || true
+  chmod 775 "$wrapper_path" 2>/dev/null || true
 }
 
 # -------- argument parsing --------
@@ -169,6 +213,13 @@ if [[ "${1:-}" == "--simple" ]]; then
   shift || true
 elif [[ "${1:-}" == "--checkpoint" ]]; then
   MODE="checkpoint"
+  shift || true
+fi
+
+# Optional: refuse-to-overwrite guard can be bypassed with --force
+FORCE=0
+if [[ "${1:-}" == "--force" ]]; then
+  FORCE=1
   shift || true
 fi
 
@@ -182,7 +233,7 @@ CRDS_DIR="$CRDS_DIR_DEFAULT"
 CRDS_LAYOUT="$LAYOUT_DEFAULT"
 
 if [[ "$MODE" == "structured" ]]; then
-  if [ "$#" -lt 4 ] || [ "$#" -gt 6 ]; then
+  if [[ "$#" -lt 4 || "$#" -gt 6 ]]; then
     usage
     exit 1
   fi
@@ -201,13 +252,10 @@ if [[ "$MODE" == "structured" ]]; then
     /*) : ;;
     *) echo "Error: <rootdir> must be an absolute path (got '$ROOTDIR')." >&2; exit 1 ;;
   esac
-  if [ ! -d "$ROOTDIR" ]; then
-    echo "Error: <rootdir> '$ROOTDIR' does not exist or is not a directory." >&2
-    exit 1
-  fi
+  [[ -d "$ROOTDIR" ]] || { echo "Error: <rootdir> '$ROOTDIR' does not exist or is not a directory." >&2; exit 1; }
 
   VISIT_ROOT="${ROOTDIR%/}/JWST/${PLANET}/${VISIT}"
-  if [ ! -d "$(dirname "$VISIT_ROOT")" ]; then
+  if [[ ! -d "$(dirname "$VISIT_ROOT")" ]]; then
     echo "Error: Parent directory '$(dirname "$VISIT_ROOT")' does not exist." >&2
     echo "Create $ROOTDIR/JWST/$PLANET first, or fix your arguments." >&2
     exit 1
@@ -217,7 +265,7 @@ if [[ "$MODE" == "structured" ]]; then
     "$STRUCT_TEMPLATE_PATH" "$BANNER_TEMPLATE_PATH" "$WRAPPER_TEMPLATE_PATH"
 
 elif [[ "$MODE" == "simple" ]]; then
-  if [ "$#" -gt 2 ]; then
+  if [[ "$#" -gt 2 ]]; then
     usage
     exit 1
   fi
@@ -233,7 +281,7 @@ elif [[ "$MODE" == "checkpoint" ]]; then
   #   <rootdir> <planet> <checkpoint> <analyst> <max_visit_num>
   # Optional:
   #   [<crds_dir>] [split|single]
-  if [ "$#" -lt 5 ] || [ "$#" -gt 7 ]; then
+  if [[ "$#" -lt 5 || "$#" -gt 7 ]]; then
     usage
     exit 1
   fi
@@ -250,10 +298,7 @@ elif [[ "$MODE" == "checkpoint" ]]; then
     /*) : ;;
     *) echo "Error: <rootdir> must be an absolute path (got '$ROOTDIR')." >&2; exit 1 ;;
   esac
-  if [ ! -d "$ROOTDIR" ]; then
-    echo "Error: <rootdir> '$ROOTDIR' does not exist or is not a directory." >&2
-    exit 1
-  fi
+  [[ -d "$ROOTDIR" ]] || { echo "Error: <rootdir> '$ROOTDIR' does not exist or is not a directory." >&2; exit 1; }
 
   if ! [[ "$MAX_VISIT_RAW" =~ ^[0-9]+$ ]]; then
     echo "Error: <max_visit_num> must be an integer (got '$MAX_VISIT_RAW')." >&2
@@ -266,7 +311,7 @@ elif [[ "$MODE" == "checkpoint" ]]; then
   fi
 
   PLANET_DIR="${ROOTDIR%/}/JWST/${PLANET}"
-  if [ ! -d "$PLANET_DIR" ]; then
+  if [[ ! -d "$PLANET_DIR" ]]; then
     echo "Error: planet directory does not exist: $PLANET_DIR" >&2
     echo "Create $ROOTDIR/JWST/$PLANET first, or fix your arguments." >&2
     exit 1
@@ -284,11 +329,14 @@ fi
 ANALYST_UID="$(id -u)"
 ANALYST_GID="$(id -g)"
 
-# Prefer rwddt group GID in split layout if it exists
-if [ "$CRDS_LAYOUT" = "split" ]; then
-  RWDDT_GID="$(perl -e 'my @g = getgrnam shift; print $g[2] if @g' rwddt)" || true
-  if [[ -n "${RWDDT_GID}" ]]; then
-    ANALYST_GID="${RWDDT_GID}"
+# Prefer a shared group (derived from ROOTDIR) in split layout if possible.
+# This avoids hard-coding any institute-specific group name into a public repo.
+if [[ "$CRDS_LAYOUT" = "split" && -n "$ROOTDIR" ]]; then
+  if ROOT_GNAME="$(get_rootdir_group_name "$ROOTDIR" 2>/dev/null)"; then
+    ROOT_GID="$(gid_of_group "$ROOT_GNAME" || true)"
+    if [[ -n "${ROOT_GID:-}" ]]; then
+      ANALYST_GID="$ROOT_GID"
+    fi
   fi
 fi
 
@@ -311,7 +359,7 @@ case "$CRDS_LAYOUT" in
 esac
 
 # Ensure a local CRDS directory exists for single layout
-if [ "$CRDS_LAYOUT" = "single" ]; then
+if [[ "$CRDS_LAYOUT" = "single" ]]; then
   mkdir -p "${CRDS_DIR}" || true
 fi
 
@@ -334,7 +382,6 @@ HOST_PORT="$(find_free_port)" || { echo "could not find a free port" >&2; exit 1
 
 # -------- naming + run directory --------
 USER_SAFE="$(sanitize "${USER:-unknown}")"
-
 PLANET_SAFE="$(sanitize "${PLANET:-unknown}")"
 
 if [[ "$MODE" == "structured" ]]; then
@@ -351,7 +398,6 @@ if [[ "$MODE" == "structured" ]]; then
   UNCAL_DIR="$BASE_VISIT_DIR/Uncalibrated"
 
   mkdir -p "$NOTEBOOKS_DIR"
-
   # Ensure minimum perms (add-only; never reduces existing perms)
   chmod u+rwx "$ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
   chmod g+s "$ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
@@ -359,6 +405,7 @@ if [[ "$MODE" == "structured" ]]; then
 
 elif [[ "$MODE" == "simple" ]]; then
   TS="$(date +%Y%m%d_%H%M%S)"
+  # Include planet + checkpoint + maxvisit so multiple checkpoints don't collide
   DATASET_SAFE="simple_${TS}"
   RUN_DIR="${RUNS_ROOT}/${DATASET_SAFE}"
   PROJECT_NAME="rwddt_${USER_SAFE}_${DATASET_SAFE}"
@@ -370,7 +417,6 @@ elif [[ "$MODE" == "simple" ]]; then
 
 elif [[ "$MODE" == "checkpoint" ]]; then
   CHECKPOINT_SAFE="$(sanitize "$CHECKPOINT")"
-  # Include planet + checkpoint + maxvisit so multiple checkpoints don't collide
   DATASET_SAFE="${PLANET_SAFE}_${CHECKPOINT_SAFE}_maxvisit${MAX_VISIT_NUM}"
   RUN_DIR="${RUNS_ROOT}/${DATASET_SAFE}"
   PROJECT_NAME="rwddt_${USER_SAFE}_${DATASET_SAFE}"
@@ -383,9 +429,9 @@ elif [[ "$MODE" == "checkpoint" ]]; then
   chmod g+s "$CHECKPOINT_ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
   chmod o+x  "$CHECKPOINT_ANALYSIS_DIR" "$NOTEBOOKS_DIR" 2>/dev/null || true
 
-  ANALYSIS_DIR=""       # not used
-  MAST_STAGE1_DIR=""    # not used
-  UNCAL_DIR=""          # not used
+  ANALYSIS_DIR=""
+  MAST_STAGE1_DIR=""
+  UNCAL_DIR=""
 fi
 
 mkdir -p "$RUN_DIR"
@@ -393,6 +439,16 @@ mkdir -p "$RUN_DIR"
 OUTPUT_PATH="${RUN_DIR}/${OUTPUT_FILE}"
 STATE_PATH="${RUN_DIR}/${STATE_FILE}"
 WRAPPER_PATH="${RUN_DIR}/${WRAPPER}"
+
+# Safety: do not overwrite an existing run's generated outputs unless --force is given
+if [[ "$FORCE" -ne 1 ]]; then
+  if [[ -e "$OUTPUT_PATH" || -e "$STATE_PATH" || -e "$WRAPPER_PATH" ]]; then
+    echo "Error: run outputs already exist in: $RUN_DIR" >&2
+    echo "  Refusing to overwrite existing docker-compose.yml/state/wrapper." >&2
+    echo "  Re-run with --force if you really want to regenerate in-place." >&2
+    exit 1
+  fi
+fi
 
 # -----------------------------------------------------------------------------
 # Generate docker-compose.yml from template (all modes)
@@ -473,7 +529,7 @@ if [[ "$MODE" == "structured" ]]; then
   replace_placeholder "$OUTPUT_PATH" "uncalibrated_host" "$UNCAL_DIR"
 
   replace_placeholder "$OUTPUT_PATH" "planet" "$PLANET"
-  replace_placeholder "$OUTPUT_PATH" "visit" "$VISIT"     # "visit#"
+  replace_placeholder "$OUTPUT_PATH" "visit" "$VISIT"
   replace_placeholder "$OUTPUT_PATH" "analyst" "$ANALYST"
 fi
 
@@ -530,6 +586,9 @@ write_kv() {
 cp "$WRAPPER_TEMPLATE_PATH" "$WRAPPER_PATH"
 chmod +x "$WRAPPER_PATH"
 
+# Fix permissions/group (some sed -i implementations/filesystems can reset perms/group)
+fix_run_permissions "$RUN_DIR" "$OUTPUT_PATH" "$STATE_PATH" "$WRAPPER_PATH"
+
 GREEN='\033[1;32m'; NC='\033[0m'
 echo "Generated run directory: $RUN_DIR"
 echo "  compose  = \"$OUTPUT_PATH\""
@@ -553,11 +612,11 @@ if [[ "$MODE" == "structured" ]]; then
 elif [[ "$MODE" == "checkpoint" ]]; then
   echo
   echo "Checkpoint dataset:"
-  echo "  planet     = \"$PLANET\""
-  echo "  checkpoint = \"$CHECKPOINT\""
-  echo "  analyst    = \"$ANALYST\""
-  echo "  max_visit  = \"$MAX_VISIT_NUM\""
-  echo "  mounted    = \"$MOUNTED_VISITS_CSV\""
+  echo "  planet       = \"$PLANET\""
+  echo "  checkpoint   = \"$CHECKPOINT\""
+  echo "  analyst      = \"$ANALYST\""
+  echo "  max_visit    = \"$MAX_VISIT_NUM\""
+  echo "  mounted      = \"$MOUNTED_VISITS_CSV\""
   echo "  checkpointRW = \"$CHECKPOINT_ANALYSIS_DIR\""
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,11 @@ umask 0002
 # Allow opting out of strict workspace requirements for community use
 SIMPLE_MODE="${SIMPLE_MODE:-0}"
 
+# Checkpoint mode (joint fit)
+CHECKPOINT_MODE="${CHECKPOINT_MODE:-0}"   # "1" enables checkpoint behavior
+CHECKPOINT="${CHECKPOINT:-}"             # required when CHECKPOINT_MODE=1
+VISITS_CSV="${VISITS_CSV:-}"             # optional (for informational logging)
+
 # --- Make the current UID/GID resolvable (fixes "I have no name!")
 CUR_UID="$(id -u)"
 CUR_GID="$(id -g)"
@@ -52,7 +57,7 @@ check_folder() {
 safe_link() {
   local src="$1"
   local dst="$2"
-  if [ -e "$dst" ] || [ -L "$dst" ]; then
+  if [[ -e "$dst" || -L "$dst" ]]; then
     rm -rf "$dst"
   fi
   ln -s "$src" "$dst"
@@ -67,8 +72,16 @@ ANALYST="${ANALYST:-}"
 HOST_PORT="${HOST_PORT:-8888}"   # used for the log line only; container binds 8888
 CONDA_ENV="${CONDA_ENV:-base}"
 
-# Community-friendly defaults: if not provided, fall back to a simple workspace
-if [[ -z "$PLANET" || -z "$VISIT" || -z "$ANALYST" ]]; then
+# Normalize mode relationships:
+if [[ "$SIMPLE_MODE" = "1" && "$CHECKPOINT_MODE" = "1" ]]; then
+  echo "Warning: SIMPLE_MODE=1 and CHECKPOINT_MODE=1 both set; SIMPLE_MODE wins." >&2
+  CHECKPOINT_MODE="0"
+fi
+
+# Establish BASE_PATH:
+# - structured:  /mnt/rwddt/JWST/<planet>/<visit>
+# - checkpoint:  /mnt/rwddt/JWST/<planet>/<checkpoint>
+if [[ -z "$PLANET" || -z "$ANALYST" ]]; then
   if [[ "$SIMPLE_MODE" = "1" ]]; then
     echo "SIMPLE_MODE=1 -> Using a generic workspace under /home/rwddt/work"
     mkdir -p /home/rwddt/work/notebooks
@@ -77,56 +90,104 @@ if [[ -z "$PLANET" || -z "$VISIT" || -z "$ANALYST" ]]; then
     : "${VISIT:=visit}"
     : "${ANALYST:=analyst}"
   else
-    die "Missing PLANET/VISIT/ANALYST env vars. Set SIMPLE_MODE=1 to use a local workspace."
+    die "Missing PLANET/ANALYST env vars. Set SIMPLE_MODE=1 to use a local workspace."
   fi
 else
-  BASE_PATH="/mnt/rwddt/JWST/${PLANET}/${VISIT}"
+  if [[ "$CHECKPOINT_MODE" = "1" ]]; then
+    [[ -n "$CHECKPOINT" ]] || die "CHECKPOINT_MODE=1 requires CHECKPOINT env var to be set."
+    BASE_PATH="/mnt/rwddt/JWST/${PLANET}/${CHECKPOINT}"
+  else
+    [[ -n "$VISIT" ]] || die "Structured mode requires VISIT env var (or set SIMPLE_MODE=1)."
+    BASE_PATH="/mnt/rwddt/JWST/${PLANET}/${VISIT}"
+  fi
 fi
 
-# Ensure required mounts/paths exist (structured mode only)
-if [[ "$SIMPLE_MODE" != "1" ]]; then
-  # Do NOT require the visit root to be mounted. We mount only specific subdirs.
-  # Create the visit directory path as a scaffold (harmless if already present).
-  mkdir -p "$BASE_PATH" || true
+# Ensure mount root exists (scaffold only; harmless if already present)
+mkdir -p /mnt/rwddt/JWST || true
+mkdir -p /home/rwddt || true
 
-  # The analyst directory must exist (it should be provided by the RW mount).
-  check_folder "${BASE_PATH}/${ANALYST}" "analyst folder mount"
-fi
+# ---------- Canonical /home/rwddt structure ----------
+# Structured mode expects:
+#   /home/rwddt/analysis
+#   /home/rwddt/notebooks
+#   /home/rwddt/MAST_Stage1
+#   /home/rwddt/Uncalibrated
+#
+# Checkpoint mode expects:
+#   /home/rwddt/analysis
+#   /home/rwddt/notebooks
+#   /home/rwddt/visits
+# and does NOT create MAST_Stage1/Uncalibrated.
 
 # ---------- link the working dirs safely ----------
 if [[ "$SIMPLE_MODE" = "1" ]]; then
+  # Simple mode: create canonical dirs locally (keeps older assumptions happy)
   mkdir -p /home/rwddt/analysis /home/rwddt/notebooks /home/rwddt/MAST_Stage1 /home/rwddt/Uncalibrated
 else
-  # Always link analysis + notebooks (analyst folder is mounted RW)
+  # Non-simple: analyst dir must exist (provided by RW mount)
+  mkdir -p "$BASE_PATH" || true
+  check_folder "${BASE_PATH}/${ANALYST}" "analyst folder mount"
+
+  # Link analysis + notebooks to the writable workspace
   safe_link "${BASE_PATH}/${ANALYST}" /home/rwddt/analysis
   safe_link "${BASE_PATH}/${ANALYST}/notebooks" /home/rwddt/notebooks
 
-  # Optional shared inputs:
-  # If they are mounted, link to them; otherwise keep empty directories so notebooks see stable paths.
-  if [[ -d "${BASE_PATH}/MAST_Stage1" ]]; then
-    safe_link "${BASE_PATH}/MAST_Stage1" /home/rwddt/MAST_Stage1
-  else
-    mkdir -p /home/rwddt/MAST_Stage1
-  fi
+  if [[ "$CHECKPOINT_MODE" = "1" ]]; then
+    # Provide a tidy portal to all visits under this planet:
+    mkdir -p "/mnt/rwddt/JWST/${PLANET}" || true
+    safe_link "/mnt/rwddt/JWST/${PLANET}" /home/rwddt/visits
 
-  if [[ -d "${BASE_PATH}/Uncalibrated" ]]; then
-    safe_link "${BASE_PATH}/Uncalibrated" /home/rwddt/Uncalibrated
+    # IMPORTANT: do NOT create /home/rwddt/MAST_Stage1 or /home/rwddt/Uncalibrated in checkpoint mode.
+    # Also, if they happen to exist in the image or from a prior container run, remove them to keep home tidy.
+    rm -rf /home/rwddt/MAST_Stage1 /home/rwddt/Uncalibrated 2>/dev/null || true
   else
-    mkdir -p /home/rwddt/Uncalibrated
+    # Structured mode: link shared inputs if present; else keep empty dirs
+    if [[ -d "${BASE_PATH}/MAST_Stage1" ]]; then
+      safe_link "${BASE_PATH}/MAST_Stage1" /home/rwddt/MAST_Stage1
+    else
+      mkdir -p /home/rwddt/MAST_Stage1
+    fi
+
+    if [[ -d "${BASE_PATH}/Uncalibrated" ]]; then
+      safe_link "${BASE_PATH}/Uncalibrated" /home/rwddt/Uncalibrated
+    else
+      mkdir -p /home/rwddt/Uncalibrated
+    fi
   fi
 fi
+
 
 echo "------------------------------------------------------------"
 echo " Verifying required volume mounts..."
 echo "------------------------------------------------------------"
 echo "Running as: $(id)"
-echo "PLANET=${PLANET}  VISIT=${VISIT}  ANALYST=${ANALYST}"
+echo "SIMPLE_MODE=${SIMPLE_MODE}  CHECKPOINT_MODE=${CHECKPOINT_MODE}"
+if [[ "$CHECKPOINT_MODE" = "1" && "$SIMPLE_MODE" != "1" ]]; then
+  echo "PLANET=${PLANET}  CHECKPOINT=${CHECKPOINT}  ANALYST=${ANALYST}"
+  if [[ -n "$VISITS_CSV" ]]; then
+    echo "VISITS_CSV=${VISITS_CSV}"
+  fi
+else
+  echo "PLANET=${PLANET}  VISIT=${VISIT:-}  ANALYST=${ANALYST}"
+fi
+echo "Resolved analysis  -> $(readlink -f /home/rwddt/analysis || true)"
 echo "Resolved notebooks -> $(readlink -f /home/rwddt/notebooks || true)"
+if [[ "$CHECKPOINT_MODE" = "1" && "$SIMPLE_MODE" != "1" ]]; then
+  echo "Resolved visits    -> $(readlink -f /home/rwddt/visits || true)"
+fi
 
 check_folder /home/rwddt/notebooks "notebooks"
 check_folder /home/rwddt/analysis "analysis"
-check_folder /home/rwddt/MAST_Stage1 "MAST Stage1" warn
-check_folder /home/rwddt/Uncalibrated "Uncalibrated" warn
+
+# Only verify Stage1/Uncalibrated paths in structured or simple mode (NOT checkpoint).
+if [[ "$CHECKPOINT_MODE" != "1" ]]; then
+  check_folder /home/rwddt/MAST_Stage1 "MAST Stage1" warn
+  check_folder /home/rwddt/Uncalibrated "Uncalibrated" warn
+fi
+
+if [[ "$CHECKPOINT_MODE" = "1" && "$SIMPLE_MODE" != "1" ]]; then
+  check_folder /home/rwddt/visits "visits"
+fi
 
 # CRDS handling:
 # - If CRDS_MODE=local, require CRDS_PATH to exist (could be /grp/crds/cache or /crds).
@@ -147,8 +208,8 @@ export CRDS_PATH
 export CRDS_SERVER_URL="${CRDS_SERVER_URL:-https://jwst-crds.stsci.edu}"
 
 # ---------- seed default notebooks (only if empty and writable) ----------
-if [ -d /opt/default_notebooks ] && [ -w /home/rwddt/notebooks ]; then
-  if [ -z "$(ls -A /home/rwddt/notebooks 2>/dev/null)" ]; then
+if [[ -d /opt/default_notebooks && -w /home/rwddt/notebooks ]]; then
+  if [[ -z "$(ls -A /home/rwddt/notebooks 2>/dev/null)" ]]; then
     cp -r /opt/default_notebooks/* /home/rwddt/notebooks/ || true
   fi
 fi
@@ -159,7 +220,7 @@ GREEN='\033[0;32m'; NC='\033[0m'
 # Activate conda
 eval "$(conda shell.bash hook)"
 export CONDA_CHANGEPS1=no
-conda activate "$CONDA_ENV"
+conda activate "${CONDA_ENV}"
 
 # Final prompt in terminals: [user@host cwd]$
 # Use \u to respect NSS wrapper username; \W shows only the leaf dir (e.g. notebooks)
@@ -215,3 +276,4 @@ echo "Detach from tmux with Ctrl-b then d."
 while tmux has-session -t "$SESSION" 2>/dev/null; do
   sleep 5
 done
+

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -1,10 +1,13 @@
-# Template for RW-DDT Jupyter container
-# Replace <project_name>, <analysis_dir_host>, <mast_stage1_host>, <uncalibrated_host>,
-# <planet>, <visit>, <analyst>, <uid>, <gid>, <hostport>,
-# <crds_dir>, <crds_target>, <crds_bind_mode>, and <crds_path>.
+# Template for RW-DDT Jupyter container (CHECKPOINT MODE)
+# Replace:
+#   <project_name>, <checkpoint_dir_host>, <planet>, <checkpoint>, <analyst>,
+#   <uid>, <gid>, <hostport>,
+#   <crds_dir>, <crds_target>, <crds_bind_mode>, <crds_path>.
 #
-# Note: <visit> should be the visit directory name (e.g., "visit12").
-# Do not commit this file after filling in paths. Keep user-specific versions local.
+# Visit mounts are injected by configure_docker_compose.sh at the marker:
+#   # __VISIT_ROOT_MOUNTS__
+#
+# Do not commit generated docker-compose.yml files; they contain local absolute paths.
 
 # IMPORTANT:
 # Compose isolates resources by "project name". Since multiple analysts may run on a shared host,
@@ -38,14 +41,11 @@ services:
       - "<hostport>:8888"
 
     volumes:
-      # Analyst folder (RW)
-      - <analysis_dir_host>:/mnt/rwddt/JWST/<planet>/<visit>/<analyst>:rw
+      # Checkpoint analyst folder (RW)
+      - <checkpoint_dir_host>:/mnt/rwddt/JWST/<planet>/<checkpoint>/<analyst>:rw
 
-      # Optional shared Stage 1 inputs (RO) — uncomment ONLY if host dir exists
-      # - <mast_stage1_host>:/mnt/rwddt/JWST/<planet>/<visit>/MAST_Stage1:ro
-
-      # Optional shared Stage 0 inputs (RO) — uncomment ONLY if host dir exists
-      # - <uncalibrated_host>:/mnt/rwddt/JWST/<planet>/<visit>/Uncalibrated:ro
+      # Read-only mounts for visit roots (injected by script)
+      # __VISIT_ROOT_MOUNTS__
 
       # CRDS mount
       #   split layout:  <crds_dir>:/grp/crds:ro
@@ -61,11 +61,11 @@ services:
     environment:
       TZ: ${TZ:-UTC}
 
-      # Structured mode by default
-      SIMPLE_MODE: ${SIMPLE_MODE:-0}
+      # Force non-simple workspace
+      SIMPLE_MODE: "0"
 
-      # Explicitly force non-checkpoint behavior in structured mode
-      CHECKPOINT_MODE: "0"
+      # Enable checkpoint behavior in entrypoint.sh
+      CHECKPOINT_MODE: "1"
 
       # CRDS settings:
       CRDS_MODE: ${CRDS_MODE:-local}
@@ -77,8 +77,14 @@ services:
       HOST_PORT: <hostport>
 
       PLANET: "<planet>"
-      VISIT: "<visit>"
+      CHECKPOINT: "<checkpoint>"
       ANALYST: "<analyst>"
+
+      # VISIT intentionally blank in checkpoint mode
+      VISIT: ""
+
+      # Optional informational field (left empty unless you decide to inject it)
+      VISITS_CSV: ${VISITS_CSV:-}
 
     restart: unless-stopped
 

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -4,8 +4,7 @@
 #   <uid>, <gid>, <hostport>,
 #   <crds_dir>, <crds_target>, <crds_bind_mode>, <crds_path>.
 #
-# Visit mounts are injected by configure_docker_compose.sh at the marker:
-#   # __VISIT_ROOT_MOUNTS__
+# Visit mounts are injected by configure_docker_compose.sh
 #
 # Do not commit generated docker-compose.yml files; they contain local absolute paths.
 

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -27,7 +27,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-5c0bd24}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -40,6 +40,9 @@ services:
       # Force Simple Mode workspace inside container
       SIMPLE_MODE: "1"
 
+      # Explicitly force non-checkpoint behavior in simple mode
+      CHECKPOINT_MODE: "0"
+
       CRDS_MODE: ${CRDS_MODE:-local}
       CRDS_PATH: ${CRDS_PATH:-<crds_path>}
 

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-5c0bd24}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -24,7 +24,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-5c0bd24}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/rwddt-run.template.sh
+++ b/templates/rwddt-run.template.sh
@@ -13,57 +13,139 @@ fi
 # shellcheck disable=SC1090
 source "$STATE_FILE"
 
-# Use sudo only if required (helps community users who can run docker without sudo)
-DOCKER="docker"
-NEED_SUDO_MSG=0
+# -----------------------------------------------------------------------------
+# Docker / Compose command selection
+#  - Prefer "docker compose" (plugin)
+#  - Fall back to "docker-compose" if needed
+#  - Use sudo only if required
+# -----------------------------------------------------------------------------
+DOCKER_BIN="docker"
+SUDO_BIN=""
+
 if ! docker info >/dev/null 2>&1; then
   if command -v sudo >/dev/null 2>&1; then
-    DOCKER="sudo docker"
-    NEED_SUDO_MSG=1
+    SUDO_BIN="sudo"
   fi
 fi
 
-# If we will be using sudo for Docker, warn before sudo authentication prompt
+# Helper to run docker (optionally via sudo)
+docker_cmd() {
+  if [[ -n "$SUDO_BIN" ]]; then
+    "$SUDO_BIN" "$DOCKER_BIN" "$@"
+  else
+    "$DOCKER_BIN" "$@"
+  fi
+}
+
+NEED_SUDO_MSG=0
+if [[ -n "$SUDO_BIN" ]]; then
+  NEED_SUDO_MSG=1
+fi
+
 if [[ "$NEED_SUDO_MSG" -eq 1 ]]; then
   echo "Note: Docker requires elevated privileges on this host." >&2
   echo "      Running Docker via sudo; you may be prompted for your password." >&2
   echo "      (Depending on sudo credential caching/TTY settings, you might not be asked every time.)" >&2
 fi
 
-DC="${DOCKER} compose -p ${PROJECT_NAME} -f ${COMPOSE_FILE}"
+# Determine whether to use "docker compose" or "docker-compose"
+COMPOSE_MODE="docker_compose_plugin"
+if docker_cmd compose version >/dev/null 2>&1; then
+  COMPOSE_MODE="docker_compose_plugin"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_MODE="docker_compose_v1"
+else
+  echo "ERROR: Neither 'docker compose' nor 'docker-compose' is available." >&2
+  echo "       Install Docker Compose plugin or docker-compose v1." >&2
+  exit 1
+fi
 
+# Build compose command as an array for safe quoting
+DC=()
+if [[ "$COMPOSE_MODE" == "docker_compose_plugin" ]]; then
+  DC=(docker_cmd compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}")
+else
+  # docker-compose v1 does not take "docker_cmd" function directly; handle sudo explicitly
+  if [[ -n "$SUDO_BIN" ]]; then
+    DC=(sudo docker-compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}")
+  else
+    DC=(docker-compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}")
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Commands
+# -----------------------------------------------------------------------------
 cmd="${1:-}"; shift || true
 case "$cmd" in
   up)
-    $DC up -d --pull missing
+    "${DC[@]}" up -d --pull missing
     echo "Started: ${PROJECT_NAME}"
     ;;
   update)
-    $DC up -d --pull always --force-recreate
+    "${DC[@]}" up -d --pull always --force-recreate
     echo "Updated: ${PROJECT_NAME}"
     ;;
   down)
-    $DC down --remove-orphans
+    "${DC[@]}" down --remove-orphans
     echo "Stopped: ${PROJECT_NAME}"
     ;;
   ps|status)
-    $DC ps
+    "${DC[@]}" ps
     ;;
   logs)
     echo "Tip: if the URL/token isn't shown yet, wait ~5–15 seconds and run './rwddt-run logs' again."
     # If stdout is a terminal, follow logs. If piped/non-interactive, print a finite tail and exit.
     if [ -t 1 ]; then
-      $DC logs -f --tail=200
+      "${DC[@]}" logs -f --tail=200
     else
-      $DC logs --tail=200
+      "${DC[@]}" logs --tail=200
     fi
     ;;
   exec)
-    $DC exec rwddt_eureka "$@"
+    "${DC[@]}" exec rwddt_eureka "$@"
+    ;;
+  info)
+    echo "Run directory: ${HERE}"
+    echo "Project:      ${PROJECT_NAME}"
+    echo "Compose file: ${COMPOSE_FILE}"
+    echo "Host port:    ${HOST_PORT}"
+    echo "Mode:         ${MODE:-structured}"
+    if [[ "${MODE:-structured}" == "checkpoint" ]]; then
+      echo "Planet:       ${PLANET}"
+      echo "Checkpoint:   ${CHECKPOINT:-}"
+      echo "Max visit:    ${MAX_VISIT_NUM:-}"
+      if [[ -n "${VISITS_CSV:-}" ]]; then
+        echo "Mounted:      ${VISITS_CSV}"
+      fi
+      echo "In-container:"
+      echo "  /home/rwddt/analysis  (RW checkpoint workspace)"
+      echo "  /home/rwddt/notebooks"
+      echo "  /home/rwddt/visits   -> /mnt/rwddt/JWST/${PLANET}"
+    else
+      echo "Planet:       ${PLANET:-}"
+      echo "Visit:        ${VISIT:-}"
+      echo "Analyst:      ${ANALYST:-}"
+      echo "In-container:"
+      echo "  /home/rwddt/analysis"
+      echo "  /home/rwddt/notebooks"
+      echo "  /home/rwddt/MAST_Stage1"
+      echo "  /home/rwddt/Uncalibrated"
+    fi
     ;;
   url)
     echo "Project: ${PROJECT_NAME}"
     echo "Host port -> container 8888: ${HOST_PORT}"
+    if [[ "${MODE:-structured}" == "checkpoint" ]]; then
+      echo
+      echo "Checkpoint mode:"
+      echo "  planet     = ${PLANET}"
+      echo "  checkpoint = ${CHECKPOINT:-}"
+      echo "  max_visit  = ${MAX_VISIT_NUM:-}"
+      if [[ -n "${VISITS_CSV:-}" ]]; then
+        echo "  mounted    = ${VISITS_CSV}"
+      fi
+    fi
     echo
     echo "Forward it (example):"
     echo "  ssh -L ${HOST_PORT}:localhost:${HOST_PORT} <user>@<remote-host>"
@@ -72,7 +154,7 @@ case "$cmd" in
     echo "  http://localhost:${HOST_PORT}/"
     ;;
   *)
-    cat <<USAGE
+    cat <<'USAGE'
 Usage: ./rwddt-run <command>
 
 Commands:
@@ -80,6 +162,7 @@ Commands:
   update    Pull newest image + force recreate
   logs      Follow logs (TTY) or print tail (piped)
   url       Show port-forward + URL
+  info      Show configuration summary for this run directory
   ps        Status
   exec ...  Run a command inside container (e.g. ./rwddt-run exec bash)
   down      Stop/remove this dataset container
@@ -87,3 +170,4 @@ USAGE
     exit 1
     ;;
 esac
+


### PR DESCRIPTION
# Summary
Add checkpoint mode for multi-visit joint fits and standardize visit naming to integer inputs (canonical `visit#` directories).

# Motivation
Analysts need to ingest Stage 4 outputs from multiple prior visits (read-only) and produce new joint-fit outputs in a dedicated checkpoint workspace (read/write), while preserving the existing single-visit structured workflow and in-container path conventions.

Fixes N/A

# Changes
- Add `--checkpoint` mode to `configure_docker_compose.sh` to support joint Stage 5 workflows across `visit1..visitN` (RO mounts) with a new checkpoint workspace (RW).
- Standardize structured-mode visit input to an integer (`<visit_num>`), while accepting legacy `visit12`/`visit012` and normalizing to `visit12` (no zero padding).
- Update container startup (`entrypoint.sh`) to support checkpoint layout:
  - Structured mode retains `/home/rwddt/{analysis,notebooks,MAST_Stage1,Uncalibrated}` behavior.
  - Checkpoint mode uses `/home/rwddt/{analysis,notebooks,visits}` and intentionally does **not** create Stage1/Uncal paths.
  - Avoid printing `CHECKPOINT=...` when not running checkpoint mode.
- Harden compose templates by explicitly setting `CHECKPOINT_MODE="0"` in structured and simple templates.
- Improve `rwddt-run` wrapper:
  - Robust detection of `docker compose` vs `docker-compose` and optional sudo usage.
  - Add `info` command and enhance `url` output with mode-aware details.
- Update README with new modes, visit convention, host layout expectations, and in-container paths for structured vs checkpoint mode.

# Testing
- Local smoke test (Docker Compose v2):
  - Structured mode:
    - `./configure_docker_compose.sh /abs/root Planet 1 analyst`
    - `cd runs/planet_visit1 && ./rwddt-run up && ./rwddt-run logs`
    - Verified `/home/rwddt/analysis` and `/home/rwddt/notebooks` point to mounted RW workspace; optional Stage1/Uncal created/linked as expected.
  - Checkpoint mode:
    - `./configure_docker_compose.sh --checkpoint /abs/root Planet checkpoint1 analyst 3`
    - `cd runs/planet_checkpoint1_maxvisit3 && ./rwddt-run up && ./rwddt-run logs`
    - Verified `/home/rwddt/analysis` points to checkpoint RW workspace, `/home/rwddt/visits` points to `/mnt/rwddt/JWST/Planet`, and Stage1/Uncal paths are not created.
- Wrapper verification:
  - `./rwddt-run info` prints correct mode/config summary in both modes.
  - `./rwddt-run url` prints port-forward helper and includes checkpoint details when applicable.

# Impact
- Breaking changes: **yes**
  - Structured-mode CLI now documents `<visit_num>` as an integer and normalizes legacy forms to canonical `visit#` (no zero padding). Existing workflows that pass `visit001`-style names will be normalized and may map to different directory names than expected if users relied on zero-padding.
  - New checkpoint mode introduces additional expected host layout (`visit1..visitN`) when used.
- Backwards compatible: **yes (with normalization)**
  - Legacy structured visit inputs like `visit12` and `visit012` continue to work and map to `visit12`. Simple mode remains unchanged.

# Docs & Release Notes
- Docs updated: **yes** (`README.md`)
- Release notes snippet:
  - ```
    Added a new checkpoint mode for multi-visit joint fits: mount visit roots (visit1..visitN) read-only and write outputs to a dedicated JWST/<planet>/<checkpoint>/<analyst> workspace. Structured mode now standardizes visit inputs to integers and normalizes legacy visit strings to canonical `visit#` directory names.
    ```

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved