### PR TITLE
Updating notebook repo version to update HLSP file names.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=3a67244
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=4f6cde1
+ARG NOTEBOOKS_REF=01eb03b
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -26,7 +26,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -24,7 +24,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-3a67244}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-4f6cde1}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true


### PR DESCRIPTION
# Summary
Updating notebook repo version to update HLSP file names.

# Motivation
HLSP files were being made with "obs###" in their filenames, while they should instead be "ecl###". This updates the notebooks repo tag to make that change.

# Changes
- Updated NOTEBOOKS_REF to `01eb03b`

# Testing
- CI testing

# Impact
- Breaking changes: no
- Backwards compatible: yes

# Docs & Release Notes
- Docs updated: no

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved