### PR TITLE
Adding extra safety constraints around ecc~1 when fitting ecosw and esinw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /home/rwddt
 
 # Build args for reproducibility and optional notebooks
 ARG DEBIAN_FRONTEND=noninteractive
-ARG EUREKA_REF=3a67244
+ARG EUREKA_REF=ea3f35c
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
 ARG NOTEBOOKS_REF=01eb03b
 ARG INCLUDE_NOTEBOOKS=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /home/rwddt
 
 # Build args for reproducibility and optional notebooks
 ARG DEBIAN_FRONTEND=noninteractive
-ARG EUREKA_REF=ea3f35c
+ARG EUREKA_REF=7768b5cd
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
 ARG NOTEBOOKS_REF=01eb03b
 ARG INCLUDE_NOTEBOOKS=true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,9 +102,13 @@ else
   fi
 fi
 
-# Ensure mount root exists (scaffold only; harmless if already present)
-mkdir -p /mnt/rwddt/JWST || true
+# Ensure local home root exists.
 mkdir -p /home/rwddt || true
+
+# Only touch /mnt/rwddt when using mounted workspaces.
+if [[ "$SIMPLE_MODE" != "1" ]]; then
+    mkdir -p /mnt/rwddt/JWST || true
+fi
 
 # ---------- Canonical /home/rwddt structure ----------
 # Structured mode expects:

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -24,7 +24,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-3a67244}
+    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -24,7 +24,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
+    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -15,7 +15,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-3a67244}
+    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -15,7 +15,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
+    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -22,7 +22,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
+    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -22,7 +22,7 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-3a67244}
+    #     EUREKA_REF: ${EUREKA_REF:-ea3f35c}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
     #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}


### PR DESCRIPTION
# Summary
Updating the Eureka! repo commit hash to add extra safety constraints around ecc~1 when fitting ecosw and esinw.

# Motivation
Without this, one cannot cleanly ensure ecc<1 when imposing priors on ecosw and esinw. For optimizers this isn't a big problem, but it is for dynesty which explores more of the prior volume.

Fixes N/A

# Changes
- Increments the Eureka! commit hash

# Testing
- CI testing

# Impact
- Breaking changes: no
- Backwards compatible: yes

# Docs & Release Notes
- Docs updated: no
- Release notes snippet:
  - Adding extra safety constraints around ecc~1 when fitting ecosw and esinw with Eureka!

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved