### PR TITLE
Updating Eureka! and notebook repo commit hashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ WORKDIR /home/rwddt
 
 # Build args for reproducibility and optional notebooks
 ARG DEBIAN_FRONTEND=noninteractive
-ARG EUREKA_REF=7768b5cd
+ARG EUREKA_REF=267b560
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=01eb03b
+ARG NOTEBOOKS_REF=92a73d2
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -24,9 +24,9 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
+    #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -15,9 +15,9 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
+    #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -22,9 +22,9 @@ services:
     #   args:
     #     NB_UID: ${UID:-1000}
     #     NB_GID: ${GID:-1000}
-    #     EUREKA_REF: ${EUREKA_REF:-7768b5cd}
+    #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-01eb03b}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true


### PR DESCRIPTION
# Summary
Updating notebook repo commit hash to incorporate updated checkpoint notebooks and HLSP files, and fixing some bugs with standard HLSPs. Adds in dynesty checkpoints for Eureka! fits as well as glob-style regex for inputdir specification (e.g., so you can run Stages 4-6 on just those Stage 3 outputs with ap=5)

# Motivation
Fixes N/A

# Changes
- New notebook repo commit includes changes to produce checkpoint HLSPs and figures
- New notebook repo commit also includes bug fixes for normal single-eclipse HLSPs
- New Eureka! repo commit enables dynesty checkpoint files, allowing for resuming of interrupted fits
- New Eureka! repo commit also enables glob-style regex specification of inputdir to allow `allapers` to be used while still being able to manually exclude some earlier stage outputs

# Testing
- CI tests

# Impact
- Breaking changes: no
- Backwards compatible: yes

# Docs & Release Notes
- Docs updated: no

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved