### PR TITLE
Update NOTEBOOKS_REF to latest commit hash in Dockerfile and templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=267b560
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=40d78a3
+ARG NOTEBOOKS_REF=a7b59a4
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=267b560
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=92a73d2
+ARG NOTEBOOKS_REF=40d78a3
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -26,7 +26,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-a7b59a4}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -26,7 +26,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-a7b59a4}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -24,7 +24,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-92a73d2}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -24,7 +24,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-267b560}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-40d78a3}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-a7b59a4}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true


### PR DESCRIPTION
# Summary
Adds fixes to HLSP generation made for GJ3929b's v1.0.1 HLSPs. Adds several clarifications to the notebook templates based on initial feedback from Elena


# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved