### PR TITLE
Pull latest Docker image on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 *.swo
 *.bak
 *.tmp
+*.code-workspace
 
 # --------------------------------------------------------------------
 # RWDDT local run artifacts (DO NOT COMMIT)
@@ -63,4 +64,3 @@ analysis/
 dist/
 build/
 *.log
-

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ cd runs/<run_name>
 ./rwddt-run up
 ```
 
+`up` checks Docker Hub for a newer image each time. If the image changed, Docker Compose recreates the container from the new image; otherwise it leaves the existing container in place.
+
 Examples:
 
 ```bash
@@ -276,7 +278,7 @@ You can also print a helper snippet with:
 ./rwddt-run exec bash
 ./rwddt-run ps
 ./rwddt-run down
-./rwddt-run update   # pull newest image + recreate
+./rwddt-run update   # pull newest image + force recreation, even if unchanged
 ```
 
 ---
@@ -314,6 +316,7 @@ cd runs/simple_YYYYmmdd_HHMMSS
 Set these in your shell before running `./rwddt-run up`:
 
 - `IMAGE` — override which container image to run (useful for local builds).
+- `RWDDT_PULL_POLICY` — control image pulls for `up`: `always` (default), `missing`, or `never`. Use `never` with an image that exists only in the local Docker image store, or when working offline.
 - `CRDS_MODE=remote` — run without requiring a local CRDS cache directory on the host (uses the CRDS server).
 
 ---
@@ -323,6 +326,7 @@ Set these in your shell before running `./rwddt-run up`:
 - **No URL printed yet:** wait a few seconds and re-run `./rwddt-run logs`.
 - **Permission denied writing files:** ensure your `<analyst>` directory is writable by your host user (and group, if applicable).
 - **Two datasets at once:** each dataset gets its own run directory under `runs/`; start each from its own run directory.
+- **An existing run still does not check for updates:** regenerate its wrapper once with the same configuration command plus `--force`. Newly generated wrappers check automatically.
 
 ---
 
@@ -346,4 +350,3 @@ Set these in your shell before running `./rwddt-run up`:
 ## Support
 
 If you encounter issues, please contact the RW-DDT JWST Data Analysis team lead (Taylor Bell; @taylorbell57).
-

--- a/configure_docker_compose.sh
+++ b/configure_docker_compose.sh
@@ -628,6 +628,5 @@ echo "  ./$WRAPPER logs   # shows Jupyter URL + token"
 echo "                     # (If it looks empty at first, wait ~5–15 seconds and run it again.)"
 echo "  ./$WRAPPER url    # prints ssh port-forward helper"
 echo
-echo "If you need to update the Docker image to a new version:"
-echo "  ./$WRAPPER update # pull latest image + recreate"
-
+echo "The 'up' command checks for a newer Docker image automatically."
+echo "Use './$WRAPPER update' only to force a fresh container recreation."

--- a/templates/rwddt-run.template.sh
+++ b/templates/rwddt-run.template.sh
@@ -76,10 +76,18 @@ fi
 # -----------------------------------------------------------------------------
 # Commands
 # -----------------------------------------------------------------------------
+PULL_POLICY="${RWDDT_PULL_POLICY:-always}"
 cmd="${1:-}"; shift || true
 case "$cmd" in
   up)
-    "${DC[@]}" up -d --pull missing
+    case "$PULL_POLICY" in
+      always|missing|never) ;;
+      *)
+        echo "ERROR: RWDDT_PULL_POLICY must be one of: always, missing, never (got '$PULL_POLICY')." >&2
+        exit 1
+        ;;
+    esac
+    "${DC[@]}" up -d --pull "$PULL_POLICY"
     echo "Started: ${PROJECT_NAME}"
     ;;
   update)
@@ -158,16 +166,19 @@ case "$cmd" in
 Usage: ./rwddt-run <command>
 
 Commands:
-  up        Start container (detached), pulls if missing
-  update    Pull newest image + force recreate
+  up        Start container, checking for a newer image by default
+  update    Pull newest image + force recreate (even if unchanged)
   logs      Follow logs (TTY) or print tail (piped)
   url       Show port-forward + URL
   info      Show configuration summary for this run directory
   ps        Status
   exec ...  Run a command inside container (e.g. ./rwddt-run exec bash)
   down      Stop/remove this dataset container
+
+Environment:
+  RWDDT_PULL_POLICY=always|missing|never
+            Image pull behavior for 'up' (default: always)
 USAGE
     exit 1
     ;;
 esac
-


### PR DESCRIPTION
## Summary
- make rwddt-run up check Docker Hub for an updated image by default
- retain update as the explicit force-recreate command
- add RWDDT_PULL_POLICY for missing, never, and offline/local-image workflows
- document automatic updates and the one-time wrapper regeneration for existing runs

## Validation
- bash -n templates/rwddt-run.template.sh configure_docker_compose.sh
- git diff --check
- confirmed Docker Compose supports the --pull option