### PR TITLE
Add stage5_epf parameter to build_single_eclipse function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/rwddt
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EUREKA_REF=5b9613e
 ARG NOTEBOOKS_REPO=https://github.com/taylorbell57/rocky-worlds-notebooks.git
-ARG NOTEBOOKS_REF=d5505d6
+ARG NOTEBOOKS_REF=f6369b2
 ARG INCLUDE_NOTEBOOKS=true
 
 # Make Python stdout/stderr unbuffered for real-time logs

--- a/templates/docker-compose.checkpoint.template.yml
+++ b/templates/docker-compose.checkpoint.template.yml
@@ -26,7 +26,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-5b9613e}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-d5505d6}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-f6369b2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.simple.template.yml
+++ b/templates/docker-compose.simple.template.yml
@@ -17,7 +17,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-5b9613e}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-d5505d6}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-f6369b2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true

--- a/templates/docker-compose.template.yml
+++ b/templates/docker-compose.template.yml
@@ -24,7 +24,7 @@ services:
     #     NB_GID: ${GID:-1000}
     #     EUREKA_REF: ${EUREKA_REF:-5b9613e}
     #     NOTEBOOKS_REPO: ${NOTEBOOKS_REPO:-https://github.com/taylorbell57/rocky-worlds-notebooks.git}
-    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-d5505d6}
+    #     NOTEBOOKS_REF: ${NOTEBOOKS_REF:-f6369b2}
     #     INCLUDE_NOTEBOOKS: ${INCLUDE_NOTEBOOKS:-true}
 
     init: true


### PR DESCRIPTION
# Summary
Add stage5_epf parameter to build_single_eclipse function to allow finding of fixed t_secondary

# Impact
- Breaking changes: no
- Backwards compatible: yes

# Docs & Release Notes
- Docs updated: no
- Release notes snippet:
  - Add stage5_epf parameter to build_single_eclipse function to allow finding of fixed t_secondary

# Checklist
- [x] CI is green (lint, tests, build)
- [x] Tests added/updated where practical
- [x] Docs updated or not needed
- [x] Security considerations reviewed (secrets, credentials, PII)
- [x] If touching Docker image/workflows: multi-arch builds still succeed
- [x] All review comments addressed; threads resolved